### PR TITLE
Plofgren memory mapped reader

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -247,7 +247,8 @@ object MemoryMappedDirectedGraph {
 }
 
 
-// TODO: Remove this or replace it with
+// TODO: This is temporary; remove it and possibly replace it with a more robust command line
+// tool for converting graphs to binary format.
 object MemoryMappedDirectedGraphBenchmark {
   def readAdjacencyListToGraph(graphPath: String): DirectedGraph[Node] = {
     val filenameStart = graphPath.lastIndexOf('/') + 1

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -72,8 +72,9 @@ class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
 
   override def iterator: Iterator[Node] = (0 to nodeCount).iterator flatMap (i => getNodeById(i))
 
-  override def edgeCount: Long = outboundOffset(nodeCount) - outboundOffset(0)
+  override def edgeCount: Long = (outboundOffset(nodeCount) - outboundOffset(0)) / 4
 
+  override lazy val maxNodeId: Int = nodeCount - 1
   // Uncomment in future if maxNodeId becomes a method:
   // override def maxNodeId = nodeCount - 1
 

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -35,7 +35,7 @@ m          out-neighbor data
 m          in-neighbor data
  */
 class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
-  val data: IntLongSource = new MemoryMappedIntLongSource(file)
+  val data: MemoryMappedIntLongSource = new MemoryMappedIntLongSource(file)
 
   override val nodeCount = data.getInt(4)
 
@@ -79,6 +79,8 @@ class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
   // override def maxNodeId = nodeCount - 1
 
   override val storedGraphDir = StoredGraphDir.BothInOut
+
+  def loadGraphToRam(): Unit = data.loadFileToRam()
 }
 
 object MemoryMappedDirectedGraph {

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSource.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSource.scala
@@ -45,4 +45,11 @@ class MemoryMappedIntLongSource(file: File) extends IntLongSource {
   override def getInt(index: Long): Int = byteBuffers(bufferIndex(index)).getInt(indexWithinBuffer(index))
 
   override def getLong(index: Long): Long = byteBuffers(bufferIndex(index)).getLong(indexWithinBuffer(index))
+
+  def loadFileToRam(): Unit =
+    byteBuffers foreach (_.load())
+
+  /** Checks if all underlying MappedByteBuffers return true to isLoaded, which is system dependent. */
+  def isFileLoadedInRam(): Boolean =
+    byteBuffers forall (_.isLoaded)
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
@@ -1,6 +1,6 @@
 package com.twitter.cassovary.graph
 
-import java.io.File
+import java.io.{BufferedWriter, PrintWriter, FileWriter, File}
 import java.nio.file.NoSuchFileException
 
 import org.scalatest.{Matchers, WordSpec}
@@ -15,8 +15,17 @@ class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
     StoredGraphDir.BothInOut,
     NeighborsSortingStrategy.LeaveUnsorted)
 
+  def graphToEdgeFormat(graph: DirectedGraph[Node], edgeFile: File): Unit = {
+    val writer = new BufferedWriter(new FileWriter(edgeFile))
+    for (u <- testGraph1) {
+      for (v <- u.outboundNodes) {
+        writer.write(u.id + " " + v + "\n")
+      }
+    }
+    writer.close()
+  }
   "A MemoryMappedDirectedGraph" should {
-    " correctly store and read a graph" in {
+    " correctly store and read a graph from binary" in {
       val tempFile = File.createTempFile("graph1", ".bin")
       MemoryMappedDirectedGraph.graphToFile(testGraph1, tempFile)
       val graph1 = new MemoryMappedDirectedGraph(tempFile)
@@ -28,11 +37,26 @@ class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
       graph1.getNodeById(-1) should be(None)
       graph1.getNodeById(6) should be(None)
       graph1.getNodeById(1 << 29) should be(None)
+      tempFile.deleteOnExit()
     }
 
     " throw an error given an invalid filename" in {
       a[NoSuchFileException] should be thrownBy {
         new MemoryMappedDirectedGraph(new File("nonexistant_file_4398219812437401"))
+      }
+    }
+
+    " correctly read a list of edges" in {
+      val tempBinaryFile = File.createTempFile("graph1", ".bin")
+      val tempEdgeFile = File.createTempFile("graph1", ".txt")
+      graphToEdgeFormat(testGraph1, tempEdgeFile)
+      println(tempEdgeFile.toPath)
+      MemoryMappedDirectedGraph.edgeFileToGraph(tempEdgeFile, tempBinaryFile)
+      val graph1 = new MemoryMappedDirectedGraph(tempBinaryFile)
+      for (testNode <- testGraph1) {
+        val node = graph1.getNodeById(testNode.id).get
+        node.outboundNodes should contain theSameElementsAs (testNode.outboundNodes)
+        node.inboundNodes should contain theSameElementsAs (testNode.inboundNodes)
       }
     }
   }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
@@ -58,6 +58,9 @@ class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
       val tempFile = File.createTempFile("graph1", ".bin")
       MemoryMappedDirectedGraph.graphToFile(testGraph1, tempFile)
       val graph1 = new MemoryMappedDirectedGraph(tempFile)
+      graph1.nodeCount shouldEqual (6) // Missing nodes are still counted
+      graph1.maxNodeId shouldEqual (5)
+      graph1.edgeCount shouldEqual (5)
       for (testNode <- testGraph1) {
         val node = graph1.getNodeById(testNode.id).get
         node.outboundNodes should contain theSameElementsAs (testNode.outboundNodes)

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSourceSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSourceSpec.scala
@@ -49,6 +49,12 @@ class MemoryMappedIntLongSourceSpec extends WordSpec with Matchers {
         source.getLong((1L << 32) + 129L)
       }
 
+      // On OS X, at least, isLoaded isn't returning true immediately after calling load.  A google search finds that
+      // isLoaded is unrelaible on some OSs.
+      //source.isFileLoadedInRam() shouldBe (false)
+      source.loadFileToRam()
+      //source.isFileLoadedInRam() shouldBe (true)
+
       file.deleteOnExit()
     }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Cassovary extends Build {
         ExclusionRule(organization = "org.mockito"))
 
   val sharedSettings = Seq(
-    version := "5.2.1",
+    version := "5.2.2",
     organization := "com.twitter",
     scalaVersion := "2.11.5",
     crossScalaVersions := Seq("2.10.4", "2.11.5"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,14 +15,14 @@ object Cassovary extends Build {
         ExclusionRule(organization = "org.mockito"))
 
   val sharedSettings = Seq(
-    version := "5.1.2",
+    version := "5.2.1",
     organization := "com.twitter",
     scalaVersion := "2.11.5",
     crossScalaVersions := Seq("2.10.4", "2.11.5"),
     retrieveManaged := true,
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % "16.0.1",
-      fastUtilsDependency % "provided",
+      fastUtilsDependency, // % "provided",
       "org.mockito" % "mockito-all" % "1.8.5" % "test",
       util("core"),
       util("logging"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Cassovary extends Build {
         ExclusionRule(organization = "org.mockito"))
 
   val sharedSettings = Seq(
-    version := "5.2.3",
+    version := "5.2.4",
     organization := "com.twitter",
     scalaVersion := "2.11.5",
     crossScalaVersions := Seq("2.10.4", "2.11.5"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Cassovary extends Build {
         ExclusionRule(organization = "org.mockito"))
 
   val sharedSettings = Seq(
-    version := "5.2.2",
+    version := "5.2.3",
     organization := "com.twitter",
     scalaVersion := "2.11.5",
     crossScalaVersions := Seq("2.10.4", "2.11.5"),


### PR DESCRIPTION
@ashishgpersonal Could you take a look at this?  This is the code to read a graph from either a single adjacency list file  or a pair of sorted files (sorted by id1 and id2).  The interface of having a single input file of edges is definitely nicer, so I'd like to keep that at least for loading small graphs, but it's slower because it uses RandomAccessFile currently rather than a memory-mapped file.

Thanks.
