### PR TITLE
Plofgren efficient graph reader

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.graph
+
+import com.twitter.cassovary.util.io.{IntLongSource, MemoryMappedIntLongSource}
+import java.io._
+
+/**
+ * A graph which reads edge data from a memory mapped file.  There is no object overhead per
+ * node: the memory used for n nodes and m edges with both in-neighbor and out-neighbor access is
+ * exactly 16 + 16*n + 8*m bytes. Also, loading is very fast because no parsing of text is required.
+ * Loading time is exactly the time it takes the operating system to map data from disk into
+ * memory.  Nodes are numbered sequentially from 0 to nodeCount - 1 and must be a range of this
+ * form (i.e. nodeCount == maxNodeId + 1).
+ *
+ * When transforming a graph where nodeCount <= maxNodeId
+ * to this format, new nodes with no neighbors will be implicitly created.  Currently only supports
+ * storing both in-neighbors and out-neighbors of nodes (StoredGraphDir.BothInOut). The binary
+ * format is currently subject to change.  Node objects are created on demand when getNodeById is
+ * called.
+ */
+
+/* Storage format
+byteCount  data
+8          (reserved, later use for versioning or indicating undirected vs directed)
+8          n (i. e. the number of nodes).  Currently must be less than 2^31.
+8*(n+1)    Offsets into out-neighbor data. Index i (a Long) points to the out-neighbor data of
+           node i.  The out-neighbor data must be stored in sequential order by id, as the
+           outegree of node i is computed from the difference in offset between node i+1 and node i.
+           Index n is needed to compute the outdegree of node n - 1.
+8*(n+1)    Offsets into in-neighbor data (Longs) (Same interpretation as out-neighbor offsets)
+m          out-neighbor data
+m          in-neighbor data
+ */
+class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
+  val data: IntLongSource = new MemoryMappedIntLongSource(file)
+
+  val nodeCount = data.getLong(8).toInt // In the future we may want to support Long ids, so
+  // store nodeCount as Long
+
+  private def outboundOffset(id: Int): Long = data.getLong(16L + 8L * id)
+
+  private def outDegree(id: Int): Int = ((outboundOffset(id + 1) - outboundOffset(id)) / 4).toInt
+
+  private def inboundOffset(id: Int): Long = data.getLong(16L + 8L * (nodeCount + 1) + 8L * id)
+
+  private def inDegree(id: Int): Int = ((inboundOffset(id + 1) - inboundOffset(id)) / 4).toInt
+
+  /* Only created when needed (there is no array of these stored). */
+  private class MemoryMappedDirectedNode(override val id: Int) extends Node {
+    val nodeOutboundOffset = outboundOffset(id)
+    val nodeInboundOffset = inboundOffset(id)
+    def outboundNodes(): Seq[Int] = new IndexedSeq[Int] {
+      val length: Int = outDegree(id)
+      def apply(i: Int): Int =  data.getInt(nodeOutboundOffset + 4L * i)
+    }
+    def inboundNodes(): Seq[Int] = new IndexedSeq[Int] {
+      val length: Int = inDegree(id)
+      def apply(i: Int): Int =  data.getInt(nodeInboundOffset + 4L * i)
+    }
+  }
+
+  def getNodeById(id: Int): Option[Node] =
+    if(0 <= id && id < nodeCount) {
+      Some(new MemoryMappedDirectedNode(id))
+    } else {
+      None
+    }
+
+  def iterator: Iterator[Node] = (0 to nodeCount).iterator flatMap (i => getNodeById(i))
+
+  lazy val edgeCount: Long = outboundOffset(nodeCount) - outboundOffset(0)
+
+  override lazy val maxNodeId = nodeCount - 1
+
+  val storedGraphDir = StoredGraphDir.BothInOut
+}
+
+object MemoryMappedDirectedGraph {
+  /** Writes the given graph to the given file (overwriting it if it exists) in the current binary
+   * format.
+   */
+  def graphToFile(graph: DirectedGraph[Node], file: File): Unit = {
+    val n = graph.maxNodeId + 1 // includes both 0 and maxNodeId as ids
+    val out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(file)))
+    out.writeLong(0)
+    out.writeLong(n)
+    //The outneighbor data starts after the initial 8 bytes, n+1 Longs for outneighbors, and n+1
+    // Longs for in-neighbors
+    var outboundOffset = 16L + 8L * (n + 1) * 2
+    for (i <- 0 until n) {
+      out.writeLong(outboundOffset)
+      outboundOffset += 4 * (graph.getNodeById(i) map (_.outboundCount)).getOrElse(0)
+    }
+    out.writeLong(outboundOffset) // Needed to compute outdegree of node n-1
+
+    // The inbound data starts immediately after the outbound data
+    var inboundOffset = outboundOffset
+    for (i <- 0 until n) {
+      out.writeLong(inboundOffset)
+      inboundOffset += 4 * (graph.getNodeById(i) map (_.inboundCount)).getOrElse(0)
+    }
+    out.writeLong(inboundOffset) // Needed to compute indegree of node n-1
+
+    for (i <- 0 until n) {
+      for (v <- (graph.getNodeById(i) map (_.outboundNodes())).getOrElse(Nil)) {
+        out.writeInt(v)
+      }
+    }
+    for (i <- 0 until n) {
+      for (v <- (graph.getNodeById(i) map (_.inboundNodes())).getOrElse(Nil)) {
+        out.writeInt(v)
+      }
+    }
+    out.close()
+  }
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -222,13 +222,18 @@ object MemoryMappedDirectedGraph {
     log("finished first pass at " + new Date())
 
     val nodeCount = maxNodeId + 1
+    // Our second pass will alternate between appending new neighbor data at the end of the file,
+    // and filling in node neighbor offsets near the beginnning of the file.  A RandomAccessFile
+    // was found to be too slow (because it lacks buffering), so we will use a
+    // BufferedOutputStream for appending neighbor data, and a FileChannel for writing the
+    // neighbor offsets.
     val binaryGraphChannel = FileChannel.open(graphFile.toPath,
-      StandardOpenOption.READ, StandardOpenOption.WRITE)
+      StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)
     val binaryGraphOutput = new DataOutputStream(
       new BufferedOutputStream(new FileOutputStream(graphFile)))
     binaryGraphOutput.writeLong(0) // Reserved bytes
     binaryGraphOutput.writeLong(nodeCount.toLong)
-    // Skip past the node offset data; it will be filled in later using binaryGraphChannel
+    // Skip past the node offsets; they will be filled in later using binaryGraphChannel.
     for (i <- 0 until 2 * (nodeCount + 1)) {
       binaryGraphOutput.writeLong(0)
     }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -11,8 +11,17 @@
  */
 package com.twitter.cassovary.graph
 
+import java.util.Date
+import java.util.regex.Pattern
+
+import com.twitter.cassovary.util.FastUtilUtils
 import com.twitter.cassovary.util.io.{IntLongSource, MemoryMappedIntLongSource}
 import java.io._
+
+import it.unimi.dsi.fastutil.ints.IntArrayList
+
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
 
 /**
  * A graph which reads edge data from a memory mapped file.  There is no object overhead per
@@ -42,7 +51,7 @@ m          out-neighbor data
 m          in-neighbor data
  */
 class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
-  val data: IntLongSource = new MemoryMappedIntLongSource(file)
+  val data: MemoryMappedIntLongSource = new MemoryMappedIntLongSource(file)
 
   val nodeCount = data.getLong(8).toInt // In the future we may want to support Long ids, so
   // store nodeCount as Long
@@ -83,6 +92,12 @@ class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
   override lazy val maxNodeId = nodeCount - 1
 
   val storedGraphDir = StoredGraphDir.BothInOut
+
+  /** Loads the graph data into physical RAM.  Makes a "best effort" (see MappedByteBuffer.load()).
+    */
+  def loadToRAM(): Unit = {
+    data.loadFileToRam()
+  }
 }
 
 object MemoryMappedDirectedGraph {
@@ -122,5 +137,168 @@ object MemoryMappedDirectedGraph {
       }
     }
     out.close()
+  }
+
+  /** Parses each line of the given file, assumed to each have the form "<int><whitespace><int>"
+    * and calls the given function of each pair of ints.  Empty lines are ignored.
+    */
+  private def forEachEdge(edgeListFile: File)(f: (Int, Int) => Unit): Unit = {
+    val linePattern = Pattern.compile(raw"(\d+)\s+(\d+)")
+    for (line <- Source.fromFile(edgeListFile).getLines()
+         if line.nonEmpty) {
+      val matcher = linePattern.matcher(line)
+      if (!matcher.matches()) {
+        throw new IOException("invalid line in edge file: " + line)
+      } else {
+        val u = matcher.group(1).toInt // Groups are 1-indexed
+        val v = matcher.group(2).toInt
+        f(u, v)
+      }
+    }
+  }
+
+  /** Converts a graph to binary format.  The input is a file containing lines  of the form
+    * "<id1> <id2>", and this method will throw an IOException if any non-blank line of the file
+    * doesn't have this form.
+    * The graph in binary format is written to the given file.  This method works by splitting
+    * edges into chunks with contiguous id1 (and also chunks with contiguous id2).  Duplicate edges
+    * are omitted from the output graph.
+    *
+    * For performance, the parameter nodesPerChunk can be tuned.  It sets the number of nodes in
+    * each temporary file, for example if nodesPerChunk is 10^6, then node ids 0..(10^6-1) will
+    * be in the first chunk, ids 10^6..(2*10^6-1) will be in the second chunk, etc.  The amount
+    * of RAM used is proportional to the largest total number of edges incident on nodes in any
+    * single chunk.
+    *
+    * If logging function (e.g. System.err.println) is given, progress will be logged there
+    * */
+  def edgeFileToGraph(edgeListFile: File,
+                      graphFile: File,
+                      nodesPerChunk: Int = 1000 * 1000,
+                      log: String => Unit = (x => Unit)): Unit = {
+    val tempFilesById1 = new ArrayBuffer[File]()
+    val tempFilesById2 = new ArrayBuffer[File]()
+    val outStreamsById1 = new ArrayBuffer[DataOutputStream]()
+    val outStreamsById2 = new ArrayBuffer[DataOutputStream]()
+
+    def createAndStoreNewTemporaryFile(fileBuffer: ArrayBuffer[File],
+                                       outputStreamBuffer: ArrayBuffer[DataOutputStream]): Unit = {
+      val newFile = File.createTempFile("edge_partition", ".bin")
+      fileBuffer += newFile
+      outputStreamBuffer += new DataOutputStream(
+        new BufferedOutputStream(new FileOutputStream(newFile)))
+      newFile.deleteOnExit() // Request file gets deleted in case an exception happens
+    }
+
+    var edgesReadCount = 0L // Only needed for logging
+    var maxNodeId = 0
+
+    log("started reading graph at " + new Date())
+    forEachEdge(edgeListFile) { (id1, id2) =>
+      maxNodeId = math.max(maxNodeId, math.max(id1, id2))
+      // Increase the number of temp files if needed
+      while (maxNodeId >= tempFilesById1.size * nodesPerChunk) {
+        createAndStoreNewTemporaryFile(tempFilesById1, outStreamsById1)
+        createAndStoreNewTemporaryFile(tempFilesById2, outStreamsById2)
+      }
+
+      val outStreamById1 = outStreamsById1(id1 / nodesPerChunk)
+      outStreamById1.writeInt(id1)
+      outStreamById1.writeInt(id2)
+      val outStreamById2 = outStreamsById2(id2 / nodesPerChunk)
+      outStreamById2.writeInt(id1)
+      outStreamById2.writeInt(id2)
+      edgesReadCount += 1
+      if (edgesReadCount % (100 * 1000 * 1000) == 0) {
+        log(s"read $edgesReadCount edges")
+      }
+    }
+
+    outStreamsById1 foreach (_.close())
+    outStreamsById2 foreach (_.close())
+    log(s"read $edgesReadCount total edges (including any duplicates)")
+    log("finished first pass at " + new Date())
+
+    val nodeCount = maxNodeId + 1
+    val binaryGraph = new RandomAccessFile(graphFile, "rw")
+    binaryGraph.writeLong(0) // Reserved bytes
+    binaryGraph.writeLong(nodeCount.toLong)
+
+    // cumulativeNeighborOffset is the byte offset where neighbor data should be written next.
+    // The out-neighbor data starts after the initial 16 bytes, n+1 Longs for out-neighbors and n+1
+    // Longs for in-neighbors.
+    var cumulativeNeighborOffset = 16L + 8L * (nodeCount + 1) * 2
+
+    var halfEdgeCount = 0L // Each edge (id1, id2) has a half-edge for id1 and a half-edge for id2
+
+    // To prevent duplicated code between out-neighbor and in-neighbor writing, iterate over the
+    // neighbor types we write (first Out, then In).
+    for (neighborType <- List(GraphDir.OutDir, GraphDir.InDir)) {
+      val tempFiles = neighborType match {
+        case GraphDir.OutDir => tempFilesById1
+        case GraphDir.InDir => tempFilesById2
+      }
+      for ((tempFile, chunkIndex) <- tempFiles.zipWithIndex) {
+        // Read edges from temporary file into arrays
+        val inStream = new DataInputStream(new BufferedInputStream(
+          new FileInputStream(tempFile)))
+
+        // The last chunk might not have the full number of nodes, so compute # nodes in this chunk.
+        val nodeCountInChunk = math.min(nodesPerChunk, nodeCount - chunkIndex * nodesPerChunk)
+        val neighborArrays = Array.fill(nodeCountInChunk)(new IntArrayList())
+        // The difference between a nodeId and the corresponding index into neighborArrays
+        val nodeOffset = chunkIndex * nodesPerChunk
+        val tempFileEdgeCount = tempFile.length() / 8L
+        for (edgeIndex <- 0L until tempFileEdgeCount) {
+          val id1 = inStream.readInt()
+          val id2 = inStream.readInt()
+          neighborType match {
+            case GraphDir.OutDir => neighborArrays(id1 - nodeOffset).add(id2)
+            case GraphDir.InDir => neighborArrays(id2 - nodeOffset).add(id1)
+          }
+        }
+        inStream.close()
+
+        // Write edge data to binary file and store neighbor offsets
+        val neighborOffsets = new Array[Long](nodeCountInChunk)
+        binaryGraph.seek(cumulativeNeighborOffset)
+        for ((neighbors, i) <- neighborArrays.zipWithIndex) {
+          neighborOffsets(i) = binaryGraph.getFilePointer
+          val sortedDistinctNeighbors = FastUtilUtils.sortedDistinctInts(neighbors)
+          for (j <- 0 until sortedDistinctNeighbors.size()) {
+            val neighborId = sortedDistinctNeighbors.get(j)
+            binaryGraph.writeInt(neighborId)
+            halfEdgeCount += 1
+            if (halfEdgeCount % (100 * 1000 * 1000) == 0)
+              log(s"wrote $halfEdgeCount half edges")
+            cumulativeNeighborOffset += 4
+          }
+        }
+        // Store the ending offset for the last node
+        val finalOffset = binaryGraph.getFilePointer
+
+        // Write neighbor offsets to binary file
+        val chunkOffsetsStart = neighborType match {
+          case GraphDir.OutDir => 16L + 8L * chunkIndex * nodesPerChunk
+          case GraphDir.InDir => 16L + 8L * chunkIndex * nodesPerChunk + 8L * (nodeCount + 1)
+        }
+        binaryGraph.seek(chunkOffsetsStart)
+
+        for (offset <- neighborOffsets) {
+          binaryGraph.writeLong(offset)
+        }
+        // Edge case: For the last chunk, we need to write the final offset, in order to store
+        // the nth node's out-degree (and in-degree).
+        if (nodesPerChunk * (chunkIndex + 1) >= nodeCount) {
+          binaryGraph.writeLong(finalOffset)
+        }
+      }
+    }
+
+    log(s"wrote $halfEdgeCount half-edges")
+    binaryGraph.close()
+    tempFilesById1 foreach (_.delete())
+    tempFilesById2 foreach (_.delete())
+    log("finished writing graph at " + new Date())
   }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/FastUtilUtils.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/FastUtilUtils.scala
@@ -66,4 +66,20 @@ object FastUtilUtils {
     override def apply(idx: Int): Int = list.getInt(idx)
     override def length: Int = list.size
   }
+
+  /**
+   * Returns the distinct elements of the given list, sorted in ascending order.
+   */
+  def sortedDistinctInts(list: IntArrayList): IntArrayList = {
+    val sortedArray: Array[Int] = list.toIntArray
+    jutil.Arrays.sort(sortedArray)
+
+    val result = new IntArrayList(list.size())
+    for (i <- 0 until sortedArray.length) {
+      if (i == 0 || sortedArray(i - 1) != sortedArray(i)) {
+        result.add(sortedArray(i))
+      }
+    }
+    result
+  }
 }

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSource.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSource.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Teapot, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.twitter.cassovary.util.io
+
+import java.io.File
+import java.nio.channels.FileChannel
+import java.nio.channels.FileChannel.MapMode
+import java.nio.file.StandardOpenOption
+import java.nio.MappedByteBuffer
+
+/**
+ * Represents an arbitrarily large sequence of bytes which can be interpreted as ints or longs.
+ */
+trait IntLongSource {
+  /** Returns the int at the given byte index, which must be a multiple of 4. */
+  def getInt(index: Long): Int
+  /** Returns the Long at the given byte index, which must be a multiple of 8. */
+  def getLong(index: Long): Long
+}
+
+/**
+ * Wraps a sequence of FileChannels to enable random access on a memory mapped file of arbitrary size.
+ * Motivation: FileChannel.open only supports 2GB at a time.
+ * @param file The file containing binary data.
+ */
+
+class MemoryMappedIntLongSource(file: File) extends IntLongSource {
+  def this(fileName: String) = this(new File(fileName))
+
+  private val fileChannel = FileChannel.open(file.toPath, StandardOpenOption.READ)
+
+  // Each buffer uses int addressing, so can only access 2GB.  We'll use multiple buffers,
+  // and access 2^30 bytes per buffer.
+  // We use 2^30 bytes per buffer rather than 2^31 because fileChannel.map doesn't currently
+  // support size 2^31.
+  private val bytesPerBuffer = 1L << 30
+  // ceiling of file.length() / bytesPerBuffer
+  private val bufferCount = ((file.length() + bytesPerBuffer - 1) / bytesPerBuffer).toInt
+  private val byteBuffers: Array[MappedByteBuffer] = (0 until bufferCount).toArray map { bufferIndex =>
+    val size = if (bufferIndex + 1 < bufferCount)
+      bytesPerBuffer
+    else
+      file.length - (bufferCount - 1L) * bytesPerBuffer
+    fileChannel.map(MapMode.READ_ONLY, bufferIndex * bytesPerBuffer, size)
+  }
+  private def bufferIndex(index: Long): Int = (index >> 30).toInt
+  private def indexWithinBuffer(index: Long): Int = (index & 0x3FFFFFFF).toInt
+
+  def getInt(index: Long): Int = byteBuffers(bufferIndex(index)).getInt(indexWithinBuffer(index))
+
+  def getLong(index: Long): Long = byteBuffers(bufferIndex(index)).getLong(indexWithinBuffer(index))
+}

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSource.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSource.scala
@@ -60,4 +60,11 @@ class MemoryMappedIntLongSource(file: File) extends IntLongSource {
   def getInt(index: Long): Int = byteBuffers(bufferIndex(index)).getInt(indexWithinBuffer(index))
 
   def getLong(index: Long): Long = byteBuffers(bufferIndex(index)).getLong(indexWithinBuffer(index))
+
+  /** Loads the underlying memory mapped file into physical RAM.  Makes a "best effort" (see
+    * MappedByteBuffer.load()).
+    */
+  def loadFileToRam(): Unit =
+    byteBuffers foreach (_.load())
+
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
@@ -1,0 +1,39 @@
+package com.twitter.cassovary.graph
+
+import java.io.File
+import java.nio.file.NoSuchFileException
+
+import org.scalatest.{Matchers, WordSpec}
+
+class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
+  val testGraph1 = ArrayBasedDirectedGraph.apply(
+    Iterable(
+      NodeIdEdgesMaxId(1, Array(2, 3)),
+      NodeIdEdgesMaxId(3, Array(1, 2)),
+      NodeIdEdgesMaxId(5, Array(1))
+    ),
+    StoredGraphDir.BothInOut,
+    NeighborsSortingStrategy.LeaveUnsorted)
+
+  "A MemoryMappedDirectedGraph" should {
+    "correctly store and read a graph" in {
+      val tempFile = File.createTempFile("graph1", ".bin")
+      MemoryMappedDirectedGraph.graphToFile(testGraph1, tempFile)
+      val graph1 = new MemoryMappedDirectedGraph(tempFile)
+      for (testNode <- testGraph1) {
+        val node = graph1.getNodeById(testNode.id).get
+        node.outboundNodes should contain theSameElementsAs (testNode.outboundNodes)
+        node.inboundNodes should contain theSameElementsAs (testNode.inboundNodes)
+      }
+      graph1.getNodeById(-1) should be(None)
+      graph1.getNodeById(6) should be(None)
+      graph1.getNodeById(1 << 29) should be(None)
+    }
+
+    "throw an error given an invalid filename" in {
+      a[NoSuchFileException] should be thrownBy {
+        new MemoryMappedDirectedGraph(new File("nonexistant_file_4398219812437401"))
+      }
+    }
+  }
+}

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
@@ -1,9 +1,11 @@
 package com.twitter.cassovary.graph
 
-import java.io.File
+import java.io.{IOException, BufferedWriter, FileWriter, File}
 import java.nio.file.NoSuchFileException
 
 import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.mutable.ArrayBuffer
 
 class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
   val testGraph1 = ArrayBasedDirectedGraph.apply(
@@ -15,8 +17,38 @@ class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
     StoredGraphDir.BothInOut,
     NeighborsSortingStrategy.LeaveUnsorted)
 
+  def stringToTemporaryFile(contents: String): File = {
+    val f = File.createTempFile("invalidGraph1", ".txt")
+    val writer = new FileWriter(f)
+    writer.write(contents)
+    writer.close()
+    f.deleteOnExit()
+    f
+  }
+
+  def graphToEdgeFormat(graph: DirectedGraph[Node],
+                        edgeFile: File): Unit = {
+    val edges = new ArrayBuffer[(Int, Int)]
+    for (u <- testGraph1) {
+      for (v <- u.outboundNodes) {
+        edges += ((u.id, v))
+      }
+    }
+    edgesToFile(edges, edgeFile)
+  }
+
+  def edgesToFile(edges: Seq[(Int, Int)], edgeFile: File): Unit = {
+    val writer = new BufferedWriter(new FileWriter(edgeFile))
+    for ((u, v) <- edges) {
+      writer.write(u + " " + v + "\n")
+    }
+    // Test that empty lines are accepted by parser
+    writer.write("\n")
+    writer.close()
+  }
+
   "A MemoryMappedDirectedGraph" should {
-    "correctly store and read a graph" in {
+    "correctly store and read a graph from binary" in {
       val tempFile = File.createTempFile("graph1", ".bin")
       MemoryMappedDirectedGraph.graphToFile(testGraph1, tempFile)
       val graph1 = new MemoryMappedDirectedGraph(tempFile)
@@ -35,5 +67,52 @@ class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
         new MemoryMappedDirectedGraph(new File("nonexistant_file_4398219812437401"))
       }
     }
+
+    " correctly read a list of edges" in {
+      val tempBinaryFile = File.createTempFile("graph1", ".bin")
+      val tempEdgeFile = File.createTempFile("graph1", ".txt")
+      graphToEdgeFormat(testGraph1, tempEdgeFile)
+      MemoryMappedDirectedGraph.edgeFileToGraph(tempEdgeFile, tempBinaryFile, nodesPerChunk = 3)
+      val graph1 = new MemoryMappedDirectedGraph(tempBinaryFile)
+      for (testNode <- testGraph1) {
+        val node = graph1.getNodeById(testNode.id).get
+        node.outboundNodes.toArray should contain theSameElementsAs (testNode.outboundNodes)
+        node.inboundNodes.toArray should contain theSameElementsAs (testNode.inboundNodes)
+      }
+    }
+
+    " correctly read edge lists and remove duplicates" in {
+      val tempBinaryFile = File.createTempFile("graph1", ".bin")
+      val edgeString = "1 \t 2\n\n\n1 0\n1 2\n3 \t 1\n1 5\n1 3\n"
+      val tempEdgeFile = stringToTemporaryFile(edgeString)
+      for (nodesPerChunk <- Seq(3, 5, Integer.MAX_VALUE)) {
+        MemoryMappedDirectedGraph.edgeFileToGraph(tempEdgeFile, tempBinaryFile, nodesPerChunk)
+        val graph = new MemoryMappedDirectedGraph(tempBinaryFile)
+        graph.nodeCount shouldEqual (6)
+        val node1 = graph.getNodeById(1).get
+        node1.outboundNodes should contain theSameElementsInOrderAs Seq(0, 2, 3, 5)
+        node1.inboundNodes should contain theSameElementsInOrderAs Seq(3)
+        val node2 = graph.getNodeById(2).get
+        node2.inboundNodes should contain theSameElementsInOrderAs Seq(1)
+        val node5 = graph.getNodeById(5).get
+        node5.inboundNodes should contain theSameElementsInOrderAs Seq(1)
+      }
+    }
+
+    " throw an error given an invalid edge file" in {
+      val outputFile = File.createTempFile("graph", "dat")
+      val invalidFile1 = stringToTemporaryFile("1 2\n3")
+      an[IOException] should be thrownBy {
+        MemoryMappedDirectedGraph.edgeFileToGraph(invalidFile1, outputFile)
+      }
+      val invalidFile2 = stringToTemporaryFile("1 2\n3 4 5")
+      an[IOException] should be thrownBy {
+        MemoryMappedDirectedGraph.edgeFileToGraph(invalidFile1, outputFile)
+      }
+      val validFile1 = stringToTemporaryFile("1 \t\t 2\n\n\n3\t4")
+      // Shouldn't throw an exception
+      MemoryMappedDirectedGraph.edgeFileToGraph(validFile1, outputFile)
+    }
+
   }
 }

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraphSpec.scala
@@ -74,6 +74,7 @@ class MemoryMappedDirectedGraphSpec extends WordSpec with Matchers {
       graphToEdgeFormat(testGraph1, tempEdgeFile)
       MemoryMappedDirectedGraph.edgeFileToGraph(tempEdgeFile, tempBinaryFile, nodesPerChunk = 3)
       val graph1 = new MemoryMappedDirectedGraph(tempBinaryFile)
+      println("graph1: " + tempBinaryFile.getCanonicalPath)
       for (testNode <- testGraph1) {
         val node = graph1.getNodeById(testNode.id).get
         node.outboundNodes.toArray should contain theSameElementsAs (testNode.outboundNodes)

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSourceSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/util/io/MemoryMappedIntLongSourceSpec.scala
@@ -1,0 +1,61 @@
+package com.twitter.cassovary.util.io
+
+import java.io.{File, RandomAccessFile}
+import java.nio.file.NoSuchFileException
+
+import org.scalatest.{Matchers, WordSpec}
+
+class MemoryMappedIntLongSourceSpec extends WordSpec with Matchers {
+  "MemoryMappedIntLongSource" should {
+    "read Ints and Longs from a multi-GB file" in {
+       // create a file with ints and long at various locations
+       val intValues = Map(
+         0L -> 12,
+         4L -> -34,
+         // Make sure ints on both sides of a buffer boundary are read correctly
+         (1L << 30) - 4 -> 56,
+         (1L << 30) -> 12345678
+       )
+      val longValues = Map(
+        (1L << 32) - 8 -> 98L,
+        (1L << 32) -> -76L,
+        (1L << 32) + 128 -> 123456789012345L
+      )
+      val file = File.createTempFile("IntLongData", "dat")
+      val out = new RandomAccessFile(file, "rw")
+      for ((i, value) <- intValues) {
+        out.seek(i)
+        out.writeInt(value)
+      }
+      for ((i, value) <- longValues) {
+        out.seek(i)
+        out.writeLong(value)
+      }
+      out.close()
+
+      // Verify that the source can read the written data
+      val source = new MemoryMappedIntLongSource(file)
+      for ((i, value) <- intValues) {
+        source.getInt(i) shouldEqual (value)
+      }
+      for ((i, value) <- longValues) {
+        source.getLong(i) shouldEqual (value)
+      }
+
+      an[ArrayIndexOutOfBoundsException] should be thrownBy {
+        source.getInt(1L << 33)
+      }
+      an[IndexOutOfBoundsException] should be thrownBy {
+        source.getLong((1L << 32) + 129L)
+      }
+
+      file.deleteOnExit()
+    }
+
+    " throw an error given an invalid filename" in {
+      a[NoSuchFileException] should be thrownBy {
+        new MemoryMappedIntLongSource("nonexistant_file_4398219812437401")
+      }
+    }
+  }
+}

--- a/cassovary-examples/src/main/scala/MemoryMappedDirectedGraphExample.scala
+++ b/cassovary-examples/src/main/scala/MemoryMappedDirectedGraphExample.scala
@@ -1,0 +1,53 @@
+import java.io.File
+
+import com.twitter.cassovary.graph.StoredGraphDir._
+import com.twitter.cassovary.graph.{MemoryMappedDirectedGraph, StoredGraphDir, Node, DirectedGraph}
+import com.twitter.cassovary.util.NodeNumberer
+import com.twitter.cassovary.util.io.AdjacencyListGraphReader
+
+/**
+ * Demonstrates conversion of a graph from adjacency list format to MemoryMappedDirectedGraph
+ * binary format.
+ */
+object MemoryMappedDirectedGraphExample {
+  def readGraph(graphPath: String): DirectedGraph[Node] = {
+    val filenameStart = graphPath.lastIndexOf('/') + 1
+    val graphDirectory = graphPath.take(filenameStart)
+    val graphFilename = graphPath.drop(filenameStart)
+    println("loading graph:" + graphFilename)
+
+    val reader = new AdjacencyListGraphReader(
+      graphDirectory,
+      graphFilename,
+      new NodeNumberer.IntIdentity(),
+      _.toInt) {
+      override def storedGraphDir: StoredGraphDir = StoredGraphDir.BothInOut
+    }
+    reader.toArrayBasedDirectedGraph()
+  }
+
+  def main(args: Array[String]): Unit = {
+    var startTime = System.currentTimeMillis()
+    val testNodeId = 30000000
+    val graphName = args(1)
+    if (args(0) == "readAdj") {
+      val graph = readGraph(graphName)
+      println(s"outneighbors of node $testNodeId: " +
+        graph.getNodeById(testNodeId).get.outboundNodes())
+      val loadTime = (System.currentTimeMillis() - startTime) / 1000.0
+      println(s"Time to read adj graph: $loadTime")
+
+      val binaryFileName = graphName.substring(0, graphName.lastIndexOf(".")) + ".dat"
+      startTime = System.currentTimeMillis()
+      MemoryMappedDirectedGraph.graphToFile(graph, new File( binaryFileName))
+      val writeTime = (System.currentTimeMillis() - startTime) / 1000.0
+      println(s"Time to write binary graph: $writeTime")
+    } else if (args(0) == "readBin") {
+      val graph = new MemoryMappedDirectedGraph(new File(graphName))
+      println(s"outneighbors of node $testNodeId: " +
+        graph.getNodeById(testNodeId).get.outboundNodes())
+      val loadTime = (System.currentTimeMillis() - startTime) / 1000.0
+      println(s"Time to read binary graph: $loadTime")
+    }
+  }
+}

--- a/cassovary-examples/src/main/scala/MemoryMappedDirectedGraphExample.scala
+++ b/cassovary-examples/src/main/scala/MemoryMappedDirectedGraphExample.scala
@@ -30,7 +30,19 @@ object MemoryMappedDirectedGraphExample {
     var startTime = System.currentTimeMillis()
     val testNodeId = 30000000
     val graphName = args(1)
-    if (args(0) == "readAdj") {
+    if (args(0) == "readEdges") {
+      assert(args.length >= 2)
+      val binaryFileName = graphName.substring(0, graphName.lastIndexOf(".")) + ".dat"
+      val nodesPerChunk = if (args.length > 2)
+        args(2).toInt
+      else
+        1000 * 1000
+      MemoryMappedDirectedGraph.edgeFileToGraph(new File(graphName), new File(binaryFileName),
+        nodesPerChunk, System.err.println)
+      val writeTime = (System.currentTimeMillis() - startTime) / 1000.0
+      println(s"Time to convert graph: $writeTime")
+    }
+    else if (args(0) == "readAdj") {
       val graph = readGraph(graphName)
       println(s"outneighbors of node $testNodeId: " +
         graph.getNodeById(testNodeId).get.outboundNodes())


### PR DESCRIPTION
This allows for efficient conversion from a file with a list of edges to a binary graph file.  The amount of memory needed is less than the size of the graph, because edge data is partitioned among intermediate files.  Any duplicate edges are removed during the transformation.
@ashishgpersonal, could you take a look at this?
