### PR TITLE
Implement maxNodeId

### DIFF
--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraph.scala
@@ -28,6 +28,7 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
   private val inboundLists = new ArrayBuffer[IntArrayList]
 
   private var _nodeCount = 0
+  private var _maxNodeId = 0
 
   def this(dataIterable: Iterable[NodeIdEdgesMaxId],
             storedGraphDir: StoredGraphDir) {
@@ -115,7 +116,7 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
       None
     }
 
-  override def iterator: Iterator[DynamicNode] = (0 until maxIdBound).iterator flatMap getNodeById
+  override def iterator: Iterator[DynamicNode] = (0 to maxNodeId).iterator flatMap getNodeById
 
   /**
    * Returns the total number of directed edges in the graph.  A mutual edge, eg: A -> B and B -> A,
@@ -132,6 +133,8 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
    */
   override def nodeCount: Int = _nodeCount
   // Or this can be computed as (0 until maxIdBound) count nodeExists
+
+  override def maxNodeId: Int = _maxNodeId
 
   /**
    * Remove an edge from a {@code srdId} to {@code destId}.
@@ -195,6 +198,7 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
 
     if (!nodeExists(id)) {
       _nodeCount += 1
+      _maxNodeId = math.max(_maxNodeId, id)
       if (StoredGraphDir.isOutDirStored(storedGraphDir)) {
         addIdToList(outboundLists)
       }
@@ -206,10 +210,6 @@ class ArrayBasedDynamicDirectedGraph(val storedGraphDir: StoredGraphDir)
 
     getNodeById(id).get
   }
-  
-  
-  private def maxIdBound: Int = math.max(outboundLists.size,
-                                         inboundLists.size)
 
   // This can be overridden if a user knows there will be many nodes with no
   // neighbors, or if most nodes will have many more than 4 neighbors

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/DirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/DirectedGraph.scala
@@ -77,9 +77,7 @@ trait DirectedGraph[+V <: Node] extends Graph[V] with Iterable[V] {
   /**
    * the max node id
    */
-  lazy val maxNodeId = iterator.foldLeft(0) {
-    (mx, node) => mx max node.id
-  }
+  def maxNodeId: Int
 
   /**
    * Added default toString for debugging (prints max of 10 nodes)

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/DynamicDirectedGraphUnion.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/DynamicDirectedGraphUnion.scala
@@ -52,6 +52,8 @@ class DynamicDirectedGraphUnion(staticGraph: DirectedGraph[Node], dynamicGraph: 
     val additionalDynamicGraphIds = dynamicGraph.iterator map (_.id) filter (!staticGraph.existsNodeId(_))
     (staticGraphIds ++ additionalDynamicGraphIds) map (id => getNodeById(id).get)
   }
+
+  def maxNodeId: Int = math.max(staticGraph.maxNodeId, dynamicGraph.maxNodeId)
 }
 
 /** Represents the union of two nodes. */

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -95,7 +95,7 @@ class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
   def edgeCount: Long = (outboundOffset(nodeCount) - outboundOffset(0)) / 4
 
   val storedGraphDir = StoredGraphDir.BothInOut
-  override def maxNodeId = nodeCount - 1
+  def maxNodeId = nodeCount - 1
 
   /** Loads the graph data into physical RAM, so later graph operations don't have lag.  Makes a
     * "best effort" (see MappedByteBuffer.load()).

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/MemoryMappedDirectedGraph.scala
@@ -94,9 +94,8 @@ class MemoryMappedDirectedGraph(file: File) extends DirectedGraph[Node] {
 
   def edgeCount: Long = (outboundOffset(nodeCount) - outboundOffset(0)) / 4
 
-  override lazy val maxNodeId = nodeCount - 1
-
   val storedGraphDir = StoredGraphDir.BothInOut
+  override def maxNodeId = nodeCount - 1
 
   /** Loads the graph data into physical RAM, so later graph operations don't have lag.  Makes a
     * "best effort" (see MappedByteBuffer.load()).

--- a/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
+++ b/cassovary-core/src/main/scala/com/twitter/cassovary/graph/TestGraph.scala
@@ -30,6 +30,7 @@ case class TestGraph(nodes: Node*) extends DirectedGraph[Node] {
   nodes foreach { addNode }
 
   def nodeCount = nodeTable.size
+  def maxNodeId = nodeTable.keys.max
   def iterator = nodeTable.valuesIterator
 
   def edgeCount = iterator.foldLeft(0L) {

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/ArrayBasedDynamicDirectedGraphSpec.scala
@@ -20,8 +20,9 @@ class ArrayBasedDynamicDirectedGraphSpec extends WordSpec with Matchers with Gra
         graph.nodeCount shouldEqual i
         graph.edgeCount shouldEqual 0
         graph.getOrCreateNode(10 * i) // non-contiguous
+        graph.maxNodeId shouldEqual (10 * i)
       }
-      graph.getOrCreateNode(10) // Accessing again should increase node count
+      graph.getOrCreateNode(10) // Accessing again should not increase node count
       graph.nodeCount shouldEqual 3
       graph.nodeExists(1000000) shouldEqual false
     }
@@ -43,6 +44,7 @@ class ArrayBasedDynamicDirectedGraphSpec extends WordSpec with Matchers with Gra
         val node2 = graph.getNodeById(2).get
         node2.inboundNodes.toList shouldEqual (if(inStored) List(1) else List())
         node2.outboundNodes.toList shouldEqual (if(notMutual) List() else List(1))
+        graph.maxNodeId shouldEqual (2)
 
         // Test multi-edge
         graph.addEdgeAllowingDuplicates(1, 2)

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/ConcurrentHashMapDynamicGraphSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/ConcurrentHashMapDynamicGraphSpec.scala
@@ -10,8 +10,9 @@ class ConcurrentHashMapDynamicGraphSpec extends WordSpec with Matchers {
         graph.nodeCount shouldEqual i
         graph.edgeCount shouldEqual 0
         graph.getOrCreateNode(10 * i) // non-contiguous
+        graph.maxNodeId shouldEqual (10 * i)
       }
-      graph.getOrCreateNode(10) // Accessing again should increase node count
+      graph.getOrCreateNode(10) // Accessing again should not increase node count
       graph.nodeCount shouldEqual 3
       graph.existsNodeId(1000000) shouldEqual false
     }
@@ -21,6 +22,7 @@ class ConcurrentHashMapDynamicGraphSpec extends WordSpec with Matchers {
       graph.addEdge(1, 2)
       // For now, addEdge allows duplicates.  graph.addEdge(1, 2) // Test duplicate elimination
       graph.edgeCount shouldEqual 1
+      graph.maxNodeId shouldEqual 2
       val node1 = graph.getNodeById(1).get
       node1.inboundNodes.toList shouldEqual ( List())
       node1.outboundNodes.toList shouldEqual (List(2))
@@ -35,6 +37,8 @@ class ConcurrentHashMapDynamicGraphSpec extends WordSpec with Matchers {
       graph.addEdge(200, 2)
       oldOutboundNodes1.toList shouldEqual (List(2))
       oldInboundNodes2.toList shouldEqual (List(1))
+
+      graph.maxNodeId shouldEqual 200
 
       // Test multi-edge
       graph.addEdge(1, 2)

--- a/cassovary-core/src/test/scala/com/twitter/cassovary/graph/DynamicDirectedGraphUnionSpec.scala
+++ b/cassovary-core/src/test/scala/com/twitter/cassovary/graph/DynamicDirectedGraphUnionSpec.scala
@@ -17,11 +17,14 @@ class DynamicDirectedGraphUnionSpec extends WordSpec with Matchers {
       staticGraph1.nodeCount shouldEqual (4)
       staticGraph1.edgeCount shouldEqual(5)
       val dynamicGraph = new SynchronizedDynamicGraph()
-      dynamicGraph.addEdge(5, 6)
       val unionGraph = new DynamicDirectedGraphUnion(staticGraph1, dynamicGraph)
+      unionGraph.maxNodeId shouldEqual (5)
+
+      dynamicGraph.addEdge(5, 6)
       (unionGraph map (_.id)) should contain theSameElementsAs (Seq(1, 2, 3, 5, 6))
       unionGraph.nodeCount shouldEqual (5)
-      unionGraph.edgeCount shouldEqual(6)
+      unionGraph.edgeCount shouldEqual (6)
+      unionGraph.maxNodeId shouldEqual (6)
       unionGraph.getNodeById(5).get.outboundNodes should contain theSameElementsAs (Seq(1, 6))
       unionGraph.getNodeById(6).get.inboundNodes should contain theSameElementsAs (Seq(5))
       unionGraph.getNodeById(5).get.outboundNodes should contain theSameElementsAs (Seq(1, 6))
@@ -37,7 +40,7 @@ class DynamicDirectedGraphUnionSpec extends WordSpec with Matchers {
       unionGraph.edgeCount shouldEqual(8)
     }
 
-    " throw an error given an invalid filename" in {
+    " throw an exception given a null graph" in {
       a[NullPointerException] should be thrownBy {
         new DynamicDirectedGraphUnion(staticGraph1, null)
       }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Cassovary extends Build {
         ExclusionRule(organization = "org.mockito"))
 
   val sharedSettings = Seq(
-    version := "5.2.4",
+    version := "5.2.5-SNAPSHOT",
     organization := "com.twitter",
     scalaVersion := "2.11.5",
     crossScalaVersions := Seq("2.10.4", "2.11.5"),


### PR DESCRIPTION
Before this, maxNodeId was not implemented in dynamic graphs, but my company's use of Cassovary benefits from having maxNodeId available in all graphs. This pull request implements maxNodeId as a method in dynamic graphs.
